### PR TITLE
changed getPageLayout to get the correct parent

### DIFF
--- a/system/modules/onepagewebsite/OnePageWebsite/OnePageWebsite.php
+++ b/system/modules/onepagewebsite/OnePageWebsite/OnePageWebsite.php
@@ -325,12 +325,12 @@ class OnePageWebsite extends \Controller
 			#$arrParents = array_reverse($arrParents);
 			
 			// fetch parent pages
-			$objParents = $objDatabase->prepare("SELECT * FROM tl_page WHERE id IN(".implode(',',$arrParents).")")->execute();
-			while($objParents->next())
+			foreach($arrParents as $pid)
 			{
-				if($objParents->includeLayout)
+				$objParent = $objDatabase->prepare("SELECT * FROM tl_page WHERE id = ?")->execute( $pid ); 
+				if($objParent->includeLayout)
 				{
-					$objLayout = $objDatabase->prepare("SELECT * FROM tl_layout WHERE id=?")->limit(1)->execute($objParents->layout);
+					$objLayout = $objDatabase->prepare("SELECT * FROM tl_layout WHERE id=?")->limit(1)->execute($objParent->layout);
 					return $objLayout;
 				}
 			}


### PR DESCRIPTION
I had the following issue. Assume we have a site structure as follows:

```
Website Root [id: 1, layout: default]
  - Start [id: 2, layout: default]
    - One Page Website Reference [id: 25, layout: empty]
      - Page 1 [id: 3]
      - Page 2 [id: 4]
```

When `OnePageWebsite::getPageLayout(3)` is called, to get its or any of its parent's layout, the resulting array `$arrParents` will be correct, e.g. in this case: `[25,2]`. However, the following SQL query:

``` SQL
SELECT * FROM tl_page WHERE id IN(25,2)
```

does not return the pages in the correct order. In fact, since there is no `ORDER BY` clause, the order is undefined and arbitrary (the order in which the rows are returned depends on the internal structure of the database, it does not order by the primary key by default for example, nor by the order of the IDs in the `IN(...)` clause). In my case the SQL server returned the result in this order: `2, 25`. Which in this case meant, that the wrong page layout was selected (the page layout named `default`, instead of the page layout named `empty`).

I changed this part, so that each page is queried individually, by traversing the correctly ordered array `$arrParents`. However, this results in a few more database queries in the worst case. May be this can be improved some other way.
